### PR TITLE
fix: reconcile api response envelope

### DIFF
--- a/backend/src/controllers/AuditController.ts
+++ b/backend/src/controllers/AuditController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { auditService } from '@/services/AuditService';
 import { AuditAction, AuditStatus, ResourceType } from '@/types/audit';
 import logger from '@/utils/logger';
+import { ApiResponseHandler } from '@/utils/apiResponse';
 
 /**
  * 审计日志控制器
@@ -48,9 +49,9 @@ export class AuditController {
       
       const result = await auditService.query(queryParams);
 
-      res.json({
-        success: true,
-        data: result,
+      ApiResponseHandler.sendSuccess(res, result, {
+        message: '查询审计日志成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (error) {
       logger.error('Failed to query audit logs', {
@@ -91,9 +92,9 @@ export class AuditController {
       
       const result = await auditService.getUserAuditLogs(userId, options);
 
-      return res.json({
-        success: true,
-        data: result,
+      return ApiResponseHandler.sendSuccess(res, result, {
+        message: '获取用户审计日志成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (error) {
       logger.error('Failed to get user audit logs', {
@@ -137,9 +138,9 @@ export class AuditController {
         options
       );
 
-      return res.json({
-        success: true,
-        data: result,
+      return ApiResponseHandler.sendSuccess(res, result, {
+        message: '获取资源审计日志成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (error) {
       logger.error('Failed to get resource audit logs', {
@@ -168,9 +169,9 @@ export class AuditController {
         limit ? parseInt(limit as string, 10) : undefined
       );
 
-      res.json({
-        success: true,
-        data: logs,
+      ApiResponseHandler.sendSuccess(res, logs, {
+        message: '获取最近审计日志成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (error) {
       logger.error('Failed to get recent audit logs', {
@@ -202,9 +203,9 @@ export class AuditController {
       
       const result = await auditService.getFailedLogs(options);
 
-      res.json({
-        success: true,
-        data: result,
+      ApiResponseHandler.sendSuccess(res, result, {
+        message: '获取失败审计日志成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (error) {
       logger.error('Failed to get failed audit logs', {
@@ -282,9 +283,9 @@ export class AuditController {
       
       const statistics = await auditService.getStatistics(options);
 
-      res.json({
-        success: true,
-        data: statistics,
+      ApiResponseHandler.sendSuccess(res, statistics, {
+        message: '获取审计统计成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (error) {
       logger.error('Failed to get audit statistics', {

--- a/backend/src/controllers/DifySessionController.ts
+++ b/backend/src/controllers/DifySessionController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { difySessionService } from '@/services/DifySessionService';
 import { AgentConfigService } from '@/services/AgentConfigService';
 import logger from '@/utils/logger';
+import { ApiResponseHandler } from '@/utils/apiResponse';
 
 const agentService = new AgentConfigService();
 
@@ -52,10 +53,9 @@ export class DifySessionController {
 
       const result = await difySessionService.getConversations(agent, params);
 
-      res.status(200).json({
-        success: true,
-        data: result,
-        timestamp: new Date().toISOString(),
+      ApiResponseHandler.sendSuccess(res, result, {
+        message: '获取 Dify 会话列表成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (error) {
       logger.error('获取 Dify 会话列表失败', {
@@ -122,10 +122,9 @@ export class DifySessionController {
 
       const result = await difySessionService.getConversationMessages(agent, params);
 
-      res.status(200).json({
-        success: true,
-        data: result,
-        timestamp: new Date().toISOString(),
+      ApiResponseHandler.sendSuccess(res, result, {
+        message: '获取 Dify 会话消息成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (error) {
       logger.error('获取 Dify 会话消息失败', {
@@ -193,10 +192,9 @@ export class DifySessionController {
         user ? (user as string) : undefined
       );
 
-      res.status(200).json({
-        success: true,
-        data: result,
-        timestamp: new Date().toISOString(),
+      ApiResponseHandler.sendSuccess(res, result, {
+        message: '获取 Dify 消息详情成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (error) {
       logger.error('获取 Dify 消息详情失败', {
@@ -264,10 +262,9 @@ export class DifySessionController {
         user ? (user as string) : undefined
       );
 
-      res.status(200).json({
-        success: true,
+      ApiResponseHandler.sendSuccess(res, null, {
         message: '会话删除成功',
-        timestamp: new Date().toISOString(),
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (error) {
       logger.error('删除 Dify 会话失败', {
@@ -336,10 +333,9 @@ export class DifySessionController {
 
       const result = await difySessionService.submitFeedback(agent, params);
 
-      res.status(200).json({
-        success: true,
-        data: result,
-        timestamp: new Date().toISOString(),
+      ApiResponseHandler.sendSuccess(res, result, {
+        message: '反馈提交成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (error) {
       logger.error('提交 Dify 消息反馈失败', {
@@ -407,10 +403,9 @@ export class DifySessionController {
         user ? (user as string) : undefined
       );
 
-      res.status(200).json({
-        success: true,
-        data: result,
-        timestamp: new Date().toISOString(),
+      ApiResponseHandler.sendSuccess(res, result, {
+        message: '获取建议问题成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (error) {
       logger.error('获取 Dify 建议问题失败', {

--- a/backend/src/controllers/ProductPreviewController.ts
+++ b/backend/src/controllers/ProductPreviewController.ts
@@ -3,6 +3,7 @@ import Joi from 'joi';
 import { ProductPreviewService } from '@/services/ProductPreviewService';
 import { ApiError, ProductPreviewRequest } from '@/types';
 import logger from '@/utils/logger';
+import { ApiResponseHandler } from '@/utils/apiResponse';
 
 export class ProductPreviewController {
   private service: ProductPreviewService;
@@ -47,10 +48,9 @@ export class ProductPreviewController {
 
     try {
       const result = await this.service.generatePreview(value);
-      res.json({
-        success: true,
-        data: result,
-        timestamp: new Date().toISOString(),
+      ApiResponseHandler.sendSuccess(res, result, {
+        message: '生成现场预览成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (err: any) {
       logger.error('调用豆包图片生成接口失败', { error: err });

--- a/backend/src/controllers/SessionController.ts
+++ b/backend/src/controllers/SessionController.ts
@@ -10,6 +10,7 @@ import {
   EventQueryParams,
   ApiError
 } from '@/types';
+import { ApiResponseHandler } from '@/utils/apiResponse';
 import { getErrorMessage } from '@/utils/helpers';
 import { createErrorFromUnknown, AuthenticationError } from '@/types/errors';
 import { JsonValue } from '@/types/dynamic';
@@ -137,10 +138,9 @@ export class SessionController {
 
       const result = await this.sessionService.listHistoriesEnhanced(agentId, value as SessionListParams);
 
-      res.json({
-        success: true,
-        data: result,
-        timestamp: new Date().toISOString(),
+      ApiResponseHandler.sendSuccess(res, result, {
+        message: '获取会话列表成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (unknownError) {
       const typedError = createErrorFromUnknown(unknownError, {
@@ -218,10 +218,9 @@ export class SessionController {
 
       const result = await this.sessionService.batchOperation(agentId, value as BatchOperationOptions);
 
-      res.json({
-        success: true,
-        data: result,
-        timestamp: new Date().toISOString(),
+      ApiResponseHandler.sendSuccess(res, result, {
+        message: '批量操作完成',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (unknownError) {
       if (handleAdminAuthError(unknownError, res)) {
@@ -349,10 +348,9 @@ export class SessionController {
 
       const stats = await this.sessionService.getSessionStats(agentId, dateRange);
 
-      res.json({
-        success: true,
-        data: stats,
-        timestamp: new Date().toISOString(),
+      ApiResponseHandler.sendSuccess(res, stats, {
+        message: '获取会话统计成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (unknownError) {
       const { agentId } = req.params;
@@ -401,10 +399,9 @@ export class SessionController {
         agentId
       } as EventQueryParams);
 
-      res.json({
-        success: true,
-        data: result,
-        timestamp: new Date().toISOString(),
+      ApiResponseHandler.sendSuccess(res, result, {
+        message: '查询会话事件成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (unknownError) {
       const { agentId } = req.params;
@@ -467,10 +464,9 @@ export class SessionController {
         requestContext
       );
 
-      res.json({
-        success: true,
-        data: detail,
-        timestamp: new Date().toISOString(),
+      ApiResponseHandler.sendSuccess(res, detail, {
+        message: '获取会话详情成功',
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (unknownError) {
       const { agentId, sessionId } = req.params;
@@ -525,10 +521,9 @@ export class SessionController {
 
       await this.sessionService.deleteHistory(agentId, sessionId);
 
-      res.json({
-        success: true,
+      ApiResponseHandler.sendSuccess(res, null, {
         message: '会话删除成功',
-        timestamp: new Date().toISOString(),
+        ...(req.requestId ? { requestId: req.requestId } : {}),
       });
     } catch (unknownError) {
       if (handleAdminAuthError(unknownError, res)) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -96,8 +96,11 @@ app.use('/api/chat', chatRouter);
 // 404处理
 app.use((req, res) => {
   res.status(404).json({
-    success: false,
+    code: 'NOT_FOUND',
     message: `路由 ${req.method} ${req.path} 不存在`,
+    data: null,
+    timestamp: new Date().toISOString(),
+    ...(req.requestId ? { requestId: req.requestId } : {}),
   });
 });
 

--- a/backend/src/types/dynamic.ts
+++ b/backend/src/types/dynamic.ts
@@ -20,6 +20,7 @@ export {
   UnknownValue,
   DataPayload,
   ApiRequestPayload,
+  ApiSuccessResponse,
   ApiResponsePayload,
   ExternalServiceResponse,
   PaginationParams,

--- a/frontend/src/components/chat/MessageItem.tsx
+++ b/frontend/src/components/chat/MessageItem.tsx
@@ -10,6 +10,7 @@ import rehypeRaw from 'rehype-raw';
 import { ChatMessage, Agent, StreamStatus, InteractiveSelectParams, InteractiveInputParams, InteractiveFormItem } from '@/types';
 import 'highlight.js/styles/github-dark.css';
 import { useChatStore } from '@/store/chatStore';
+import { useMessageStore } from '@/store/messageStore';
 import { chatService } from '@/services/api';
 import { ReasoningTrail } from './ReasoningTrail';
 import { EventTrail } from './EventTrail';
@@ -221,7 +222,8 @@ export const MessageItem: React.FC<MessageItemProps> = memo(({
   const content = isUser ? message.HUMAN : message.AI;
 
   // 从全局store获取当前会话和反馈更新方法
-  const { currentSession, setMessageFeedback } = useChatStore();
+  const currentSession = useChatStore((state) => state.currentSession);
+  const setMessageFeedback = useMessageStore((state) => state.setMessageFeedback);
   const agent = currentAgent; // 已通过props传入
   const canFeedback = !isUser && !!message.id && agent?.provider === 'fastgpt';
 

--- a/frontend/src/hooks/useAgentAutoFetch.ts
+++ b/frontend/src/hooks/useAgentAutoFetch.ts
@@ -12,11 +12,11 @@ export function useAgentAutoFetch() {
     try {
       const response = await fetchAgentInfoApi(params);
       
-      if (response.success && response.data) {
+      if (response.data) {
         return response.data;
-      } else {
-        throw new Error('获取智能体信息失败');
       }
+
+      throw new Error('获取智能体信息失败');
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : '获取智能体信息失败';
       setError(errorMessage);

--- a/frontend/src/services/agentsApi.ts
+++ b/frontend/src/services/agentsApi.ts
@@ -1,4 +1,5 @@
 import { api } from './api';
+import type { ApiSuccessPayload } from '@/types/dynamic';
 
 export interface AgentItem {
   id: string;
@@ -38,7 +39,7 @@ export interface AgentPayload {
 }
 
 export async function listAgents(opts?: { includeInactive?: boolean }): Promise<AgentItem[]> {
-  const { data } = await api.get<{ success: boolean; data: AgentItem[]; total: number }>(
+  const { data } = await api.get<ApiSuccessPayload<AgentItem[]>>(
     '/agents',
     { params: { includeInactive: opts?.includeInactive ? 'true' : undefined } }
   );
@@ -46,7 +47,7 @@ export async function listAgents(opts?: { includeInactive?: boolean }): Promise<
 }
 
 export async function reloadAgents(): Promise<{ totalAgents: number; activeAgents: number }> {
-  const { data } = await api.post<{ success: boolean; data: { totalAgents: number; activeAgents: number } }>(
+  const { data } = await api.post<ApiSuccessPayload<{ totalAgents: number; activeAgents: number }>>(
     '/agents/reload',
     {}
   );
@@ -54,12 +55,12 @@ export async function reloadAgents(): Promise<{ totalAgents: number; activeAgent
 }
 
 export async function updateAgent(id: string, updates: Partial<AgentPayload>): Promise<AgentItem> {
-  const { data } = await api.put<{ success: boolean; data: AgentItem }>(`/agents/${id}`, updates);
+  const { data } = await api.put<ApiSuccessPayload<AgentItem>>(`/agents/${id}`, updates);
   return data.data;
 }
 
 export async function createAgent(payload: AgentPayload): Promise<AgentItem> {
-  const { data } = await api.post<{ success: boolean; data: AgentItem }>('/agents', payload);
+  const { data } = await api.post<ApiSuccessPayload<AgentItem>>('/agents', payload);
   return data.data;
 }
 
@@ -68,12 +69,12 @@ export async function deleteAgent(id: string): Promise<void> {
 }
 
 export async function importAgents(payload: { agents: AgentPayload[] }): Promise<AgentItem[]> {
-  const { data } = await api.post<{ success: boolean; data: AgentItem[] }>('/agents/import', payload);
+  const { data } = await api.post<ApiSuccessPayload<AgentItem[]>>('/agents/import', payload);
   return data.data;
 }
 
 export async function validateAgent(id: string): Promise<{ agentId: string; isValid: boolean; exists: boolean; isActive: boolean }> {
-  const { data } = await api.get<{ success: boolean; data: { agentId: string; isValid: boolean; exists: boolean; isActive: boolean } }>(
+  const { data } = await api.get<ApiSuccessPayload<{ agentId: string; isValid: boolean; exists: boolean; isActive: boolean }>>(
     `/agents/${id}/validate`
   );
   return data.data;
@@ -97,8 +98,8 @@ export interface AgentInfo {
   features: Record<string, any>;
 }
 
-export async function fetchAgentInfo(params: FetchAgentInfoParams): Promise<{ success: boolean; data: AgentInfo }> {
-  const { data } = await api.post<{ success: boolean; data: AgentInfo }>('/agents/fetch-info', params);
+export async function fetchAgentInfo(params: FetchAgentInfoParams): Promise<ApiSuccessPayload<AgentInfo>> {
+  const { data } = await api.post<ApiSuccessPayload<AgentInfo>>('/agents/fetch-info', params);
   return data;
 }
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { useAuthStore } from '@/store/authStore';
 import { toast } from '@/components/ui/Toast';
 import { translate } from '@/i18n';
+import type { ApiSuccessPayload } from '@/types/dynamic';
 import {
   Agent,
   OriginalChatMessage,
@@ -29,11 +30,7 @@ import {
   isUsageEvent,
 } from '@/lib/fastgptEvents';
 
-interface ApiResponse<T> {
-  data: T;
-  success?: boolean;
-  message?: string;
-}
+type ApiResponse<T> = ApiSuccessPayload<T>;
 
 interface SSECallbacks {
   onChunk: (chunk: string) => void;

--- a/frontend/src/types/dynamic.ts
+++ b/frontend/src/types/dynamic.ts
@@ -6,6 +6,7 @@
  */
 
 import type {
+  ApiSuccessResponse,
   JsonArray,
   JsonObject,
   JsonValue,
@@ -21,6 +22,7 @@ export type {
   UnknownValue,
   DataPayload,
   ApiRequestPayload,
+  ApiSuccessResponse,
   ApiResponsePayload,
   ExternalServiceResponse,
   PaginationParams,
@@ -41,6 +43,10 @@ export {
   DynamicDataConverter,
   SafeAccess
 } from '@llmchat/shared-types';
+
+export type ApiSuccessPayload<TData> = Omit<ApiSuccessResponse<JsonValue>, 'data'> & {
+  data: TData;
+};
 
 // ============================================================================
 // 前端特有的扩展类型

--- a/shared-types/src/index.ts
+++ b/shared-types/src/index.ts
@@ -68,22 +68,33 @@ export interface ApiRequestPayload {
 }
 
 /**
- * 通用API响应载荷
+ * 通用API成功响应载荷
  */
-export interface ApiResponsePayload {
-  success: boolean;
-  data?: JsonValue;
-  error?: {
-    code: string;
-    message: string;
-    details?: JsonObject;
-  };
+export interface ApiSuccessResponse<T extends JsonValue = JsonValue> {
+  code: string;
+  message: string;
+  data: T;
+  timestamp: string;
+  requestId?: string;
   metadata?: {
-    requestId?: string;
-    timestamp?: string;
-    version?: string;
+    version: string;
+    duration?: number;
+    pagination?: {
+      page: number;
+      pageSize: number;
+      total: number;
+      totalPages: number;
+      hasNext: boolean;
+      hasPrev: boolean;
+    };
+    extra?: JsonObject;
   };
 }
+
+/**
+ * 兼容别名：保持向后兼容
+ */
+export type ApiResponsePayload<T extends JsonValue = JsonValue> = ApiSuccessResponse<T>;
 
 /**
  * 外部服务通用响应


### PR DESCRIPTION
## Summary
- allow ApiResponseHandler to coerce arbitrary payloads into JSON-safe success envelopes and normalize metadata extras
- align shared and frontend types with the new { code, message, data } schema using ApiSuccessPayload helpers
- update REST controllers and agent API clients to consume the handler while keeping SSE headers consistent with global CORS

## Testing
- npm run build
- npm test
- npm run backend:lint
- npm run frontend:lint

------
https://chatgpt.com/codex/tasks/task_e_68dfdbf611f48323930368e748f1ba8c